### PR TITLE
Fix negotiation failure status

### DIFF
--- a/services/conversation_monitor.py
+++ b/services/conversation_monitor.py
@@ -7,6 +7,7 @@ from typing import Dict, Any, Optional, Callable
 from enum import Enum
 
 from config.settings import settings
+from models.campaign import NegotiationStatus
 
 logger = logging.getLogger(__name__)
 
@@ -345,7 +346,7 @@ class ConversationEventHandler:
                 # Find and update the failed negotiation
                 for negotiation in state.negotiations:
                     if negotiation.conversation_id == conversation_id:
-                        negotiation.status = "failed"
+                        negotiation.status = NegotiationStatus.FAILED
                         negotiation.failure_reason = error_message
                         negotiation.completed_at = datetime.now()
                         break


### PR DESCRIPTION
## Summary
- import NegotiationStatus in conversation_monitor
- use NegotiationStatus.FAILED when notifying orchestrator

## Testing
- `pytest -q` *(fails: No module named 'pydantic')*

------
https://chatgpt.com/codex/tasks/task_e_684d0dacdf608332b0190cd399195205