### PR TITLE
Fix polling interval comment

### DIFF
--- a/services/conversation_monitor.py
+++ b/services/conversation_monitor.py
@@ -25,7 +25,7 @@ class ConversationMonitor:
     🔄 CONVERSATION MONITOR - Polls ElevenLabs API and manages conversation lifecycle
     
     Key Features:
-    - Configurable polling intervals (10-20 seconds)
+    - Poll interval configurable via `self.poll_interval_seconds` (default 15s)
     - Automatic status detection and transition
     - Callback system for status changes
     - Proper error handling and timeouts


### PR DESCRIPTION
## Summary
- correct the polling interval description in `ConversationMonitor`

## Testing
- `python -m pytest` *(fails: No module named 'pydantic')*

------
https://chatgpt.com/codex/tasks/task_e_684d0dc6ff00833281c617af6d2f5ed7