### PR TITLE
Remove redundant voice alias

### DIFF
--- a/agents/negotiation.py
+++ b/agents/negotiation.py
@@ -6,7 +6,7 @@ from datetime import datetime
 from typing import Optional, Dict, Any
 
 from models.campaign import CampaignData, CreatorMatch, NegotiationState, NegotiationStatus, CallStatus
-from services.voice import VoiceService
+from services import VoiceService
 from services.pricing import PricingService
 
 from config.settings import settings

--- a/main.py
+++ b/main.py
@@ -163,7 +163,7 @@ async def debug_info():
         import_status["negotiation_agent"] = f"❌ Failed: {e}"
     
     try:
-        from services.voice import VoiceService
+        from services import VoiceService
         import_status["voice_service"] = "✅ Available"
     except ImportError as e:
         import_status["voice_service"] = f"❌ Failed: {e}"

--- a/services/voice.py
+++ b/services/voice.py
@@ -1,1 +1,0 @@
-from .elevenlabs_voice_service import ElevenLabsVoiceService as VoiceService


### PR DESCRIPTION
## Summary
- drop `services/voice.py` alias
- import `VoiceService` directly from `services`

## Testing
- `python test_setup.py` *(fails: No module named 'pydantic')*

------
https://chatgpt.com/codex/tasks/task_e_684d2566e53083329c78b70e0f5fec42